### PR TITLE
Fix test and deploy script with RoyaltyAllowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ GOERLI_URL=
 
 # private key for the deployer account
 PRIVATE_KEY=
+
+# private key for the deployer account
+ROYALTY_ALLOWLIST=

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,18 +1,36 @@
 import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox";
 import "@typechain/hardhat";
+import "hardhat-dependency-compiler";
 
 import * as dotenv from "dotenv";
 
 dotenv.config();
 
 const config: HardhatUserConfig = {
-  solidity: "0.8.17",
+  solidity: {
+    version: "0.8.17",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+    },
+  },
+  dependencyCompiler: {
+    paths: [
+      '@imtbl/zkevm-contracts/contracts/royalty-enforcement/RoyaltyAllowlist.sol',
+    ],
+  },
   networks: {
+    hardhat: {
+      allowUnlimitedContractSize: true,
+    },
     immutableZkevmTestnet: {
       url: "https://rpc.testnet.immutable.com",
       accounts:
         process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
+      allowUnlimitedContractSize: true,
     },
   },
   etherscan: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@imtbl/zkevm-contracts": "^1.0.3",
+        "@imtbl/zkevm-contracts": "^1.0.5",
         "@openzeppelin/contracts": "^4.8.1",
         "dotenv": "^16.0.3",
         "hardhat": "^2.12.7",
@@ -18,7 +18,8 @@
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^2.0.1",
         "@typechain/ethers-v5": "^10.2.0",
-        "@typechain/hardhat": "^6.1.5"
+        "@typechain/hardhat": "^6.1.5",
+        "hardhat-dependency-compiler": "^1.1.3"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -730,9 +731,9 @@
       }
     },
     "node_modules/@imtbl/zkevm-contracts": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@imtbl/zkevm-contracts/-/zkevm-contracts-1.0.3.tgz",
-      "integrity": "sha512-bk3sMSdWjMWD5BNTrXWNWQTNBYTlRx6CAZpyDz2X6xwjxuhV4xCVzapLR/RBOnYyEU5NJ7y0ozpm9YgzIpuGIg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@imtbl/zkevm-contracts/-/zkevm-contracts-1.0.5.tgz",
+      "integrity": "sha512-irDaR1FIhjuDtB3aYk2vSKMaxDo4mdM5O95zmdvLdTUpsQR1AByut5uiVQViXoyo7tVWB0jRJ/N3AOE0k+ZPVA==",
       "dependencies": {
         "@openzeppelin/contracts": "^4.8.1"
       }
@@ -4504,6 +4505,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/hardhat-dependency-compiler": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/hardhat-dependency-compiler/-/hardhat-dependency-compiler-1.1.3.tgz",
+      "integrity": "sha512-bCDqsOxGST6WkbMvj4lPchYWidNSSBm5CFnkyAex1T11cGmr9otZTGl81W6f9pmrtBXbKCvr3OSuNJ6Q394sAw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.14.0"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.0.0"
       }
     },
     "node_modules/hardhat-gas-reporter": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^2.0.1",
     "@typechain/ethers-v5": "^10.2.0",
-    "@typechain/hardhat": "^6.1.5"
+    "@typechain/hardhat": "^6.1.5",
+    "hardhat-dependency-compiler": "^1.1.3"
   }
 }

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -12,6 +12,11 @@ async function deploy() {
     ethers.utils.formatEther(await deployer.getBalance())
   );
 
+  const royaltyAllowlist = process.env.ROYALTY_ALLOWLIST;
+  if (royaltyAllowlist === undefined) {
+    throw new Error("Please set your ROYALTY_ALLOWLIST in a .env file");
+  }
+
   // deploy MyERC721 contract
   const MyERC721: MyERC721__factory = await ethers.getContractFactory(
     "MyERC721"
@@ -22,8 +27,8 @@ async function deploy() {
     "III", // symbol
     "https://example-base-uri.com/", // baseURI
     "https://example-contract-uri.com/", // contractURI
+    royaltyAllowlist, // royalty allowlist
     deployer.address, // royalty recipient
-    0, // royalty allowlist (0 does no allowlist checking)
     ethers.BigNumber.from("2000"), // fee numerator
   );
   await contract.deployed();


### PR DESCRIPTION
https://github.com/immutable/zkevm-contracts/commit/22d127fe4d9fde4777af9978c71c30999a661217 enforces `RoyaltyAllowlist` in contract constructor. 

The boilerplate contract `MyERC721` was updated to reflect these changes. However, the `test` and the `deploy` script were not updated.